### PR TITLE
pipx semantic changed --spec no longer needed

### DIFF
--- a/install_tools.sh
+++ b/install_tools.sh
@@ -84,9 +84,9 @@ log "Installing agent dependencies"
 install_packages pipx python3-venv sshpass jq > /dev/null
 
 log "Installing agent tools"
-pipx install --spec $TOOLS_PATH/cert-tools/launcher launcher > /dev/null
-pipx install --spec $TOOLS_PATH/cert-tools/toolbox toolbox > /dev/null
-pipx install --spec $TOOLS_PATH/cert-tools/snapstore snapstore > /dev/null
+pipx install $TOOLS_PATH/cert-tools/launcher > /dev/null
+pipx install $TOOLS_PATH/cert-tools/toolbox > /dev/null
+pipx install $TOOLS_PATH/cert-tools/snapstore > /dev/null
 
 # grab DEVICE_USER from the scenario file, if possible
 # (generally, a non-default DEVICE_USER needs to be set

--- a/scriptlets/install_checkbox_agent_source
+++ b/scriptlets/install_checkbox_agent_source
@@ -45,6 +45,6 @@ git clone --filter=tree:0 https://github.com/canonical/checkbox.git > /dev/null
 $TOOLS_PATH/version-published/checkout_to_version.py ~/checkbox "$VERSION"
 
 # install checkbox from source
-pipx install --spec checkbox/checkbox-ng checkbox-ng
+pipx install checkbox/checkbox-ng
 pipx inject checkbox-ng "urwid<3"
 sudo rm -rf checkbox


### PR DESCRIPTION
Pipx in jammy+ doens't have a spec option on install, I've removed it and now it works fine, I guess its an update to the version that is hitting. No machine is working right now

Test run: http://10.102.156.15:8080/job/cert-dawson-i-uc20-snapd-beta/109/console