### PR TITLE
Don't put submission.json into artifact after testing.

### DIFF
--- a/scriptlets/collect_artifacts
+++ b/scriptlets/collect_artifacts
@@ -26,6 +26,6 @@ find ~ -name 'submission_*.junit.xml' -exec mv {} artifacts/junit.xml \;
 find ~ -name 'submission_*.html' -exec mv {} artifacts/submission.html \;
 find ~ -name 'submission_*.tar.xz' -exec mv {} artifacts/submission.tar.xz \;
 find ~ -name 'submission_*.log' -exec mv {} artifacts/submission.log \;
-tar -xf artifacts/submission.tar.xz -C artifacts submission.json
+tar -xf artifacts/submission.tar.xz -C artifacts
 
 [ -n "$INCLUDED" ] && cp $INCLUDED artifacts

--- a/scriptlets/collect_artifacts
+++ b/scriptlets/collect_artifacts
@@ -26,6 +26,5 @@ find ~ -name 'submission_*.junit.xml' -exec mv {} artifacts/junit.xml \;
 find ~ -name 'submission_*.html' -exec mv {} artifacts/submission.html \;
 find ~ -name 'submission_*.tar.xz' -exec mv {} artifacts/submission.tar.xz \;
 find ~ -name 'submission_*.log' -exec mv {} artifacts/submission.log \;
-tar -xf artifacts/submission.tar.xz -C artifacts
 
 [ -n "$INCLUDED" ] && cp $INCLUDED artifacts


### PR DESCRIPTION
I noticed that the size of `submission.json` has grown significantly, which consumes too much disk space on our jenkins server.
Since we already have the submission.tar.xz in the artifact, I don't think is necessary to extract the json from the tar file.

This PR addresses https://warthogs.atlassian.net/browse/LM-1941.