### PR TITLE
Replace urwid hackaround with proper solution

### DIFF
--- a/scriptlets/install_checkbox_agent_source
+++ b/scriptlets/install_checkbox_agent_source
@@ -44,6 +44,6 @@ git clone --filter=tree:0 https://github.com/canonical/checkbox.git > /dev/null
 # checkout commit to match the required version
 $TOOLS_PATH/version-published/checkout_to_version.py ~/checkbox "$VERSION"
 
-# install checkbox from source
-pipx install checkbox/checkbox-ng[`lsb_release -cs`_prod]
+CHECKBOX_SOURCE_INSTALL_GROUP=${CHECKBOX_SOURCE_INSTALL_GROUP:-$(lsb_release -cs)_prod}
+pipx install checkbox/checkbox-ng[$CHECKBOX_SOURCE_INSTALL_GROUP]
 rm -rf checkbox

--- a/scriptlets/install_checkbox_agent_source
+++ b/scriptlets/install_checkbox_agent_source
@@ -45,5 +45,5 @@ git clone --filter=tree:0 https://github.com/canonical/checkbox.git > /dev/null
 $TOOLS_PATH/version-published/checkout_to_version.py ~/checkbox "$VERSION"
 
 # install checkbox from source
-pipx install checkbox/checkbox-ng[jammy_prod]
+pipx install checkbox/checkbox-ng[`lsb_release -cs`_prod]
 rm -rf checkbox

--- a/scriptlets/install_checkbox_agent_source
+++ b/scriptlets/install_checkbox_agent_source
@@ -45,6 +45,5 @@ git clone --filter=tree:0 https://github.com/canonical/checkbox.git > /dev/null
 $TOOLS_PATH/version-published/checkout_to_version.py ~/checkbox "$VERSION"
 
 # install checkbox from source
-pipx install checkbox/checkbox-ng
-pipx inject checkbox-ng "urwid<3"
-sudo rm -rf checkbox
+pipx install checkbox/checkbox-ng[jammy_prod]
+rm -rf checkbox


### PR DESCRIPTION
We had a serious regression a few weeks ago due to an urwid release. This is because Checkbox source didnt offer pinned dependencies for production, as it was intended as a development environemnt only. 

We have rectified this by creating a new pinned environment both for jammy and for noble (pending an update for the Testflinger runners). This PR removes the urwid hackaround and adopts the new proper solution

Tested locally on jammy with pipx from the archive:
```
root@jammy:~# pipx --version
1.0.0
root@jammy:~# pipx install checkbox/checkbox-ng[jammy_prod]
  installed package checkbox-ng 5.0.1.dev10+g19c2f9a5e8.d20250709, installed using Python 3.10.12
  These apps are now globally available
    - checkbox-cli
    - checkbox-provider-tools
⚠️  Note: '/root/.local/bin' is not on your PATH environment variable. These apps will not be globally accessible until
    your PATH is updated. Run `pipx ensurepath` to automatically add it, or manually modify your PATH in your shell's
    config file (i.e. ~/.bashrc).
root@jammy:~# ~/.local/bin/checkbox-cli 
Preparing...
There were no test plans to select from!
No test plan selected.
```