### PR TITLE
fix: missing required ppa in checkbox/deb scriplet

### DIFF
--- a/scriptlets/install_checkbox_debs
+++ b/scriptlets/install_checkbox_debs
@@ -52,6 +52,7 @@ echo "  See: https://code.launchpad.net/~checkbox-dev/+archive/ubuntu/$RISK"
 [ -n "$PROVIDERS" ] && echo "  Additional providers: $PROVIDERS"
 
 wait_for_packages_complete
+_run sudo add-apt-repository -y ppa:colin-king/ppa
 _run sudo add-apt-repository -y ppa:colin-king/stress-ng
 _run sudo add-apt-repository -y ppa:firmware-testing-team/ppa-fwts-stable
 _run sudo add-apt-repository -y ppa:checkbox-dev/$RISK


### PR DESCRIPTION
Cannot install stress-ng because of broken dependencies. Following [this commit](https://github.com/canonical/checkbox/commit/3ac4d97810762a2f2ba7fd04d41d9324c8f3745b) to address the issue.