### PR TITLE
install_checkbox_agent_source now requires lsb-release

### DIFF
--- a/install_tools.sh
+++ b/install_tools.sh
@@ -81,7 +81,7 @@ add_to_path $SCRIPTLETS_PATH/sru-helpers
 add_to_path ~/.local/bin
 
 log "Installing agent dependencies"
-install_packages pipx python3-venv sshpass jq > /dev/null
+install_packages pipx python3-venv sshpass jq lsb-release > /dev/null
 
 log "Installing agent tools"
 pipx install $TOOLS_PATH/cert-tools/launcher > /dev/null


### PR DESCRIPTION
[This landed ](https://github.com/canonical/certification-lab-ci-tools/pull/80) a change that requires a new dependency. lsb-release is usually pre installed on most machines but in some Ubuntu based docker images it is not anymore