### PR TITLE
fix: run `wait_for_packages_complete` on the device

### DIFF
--- a/scriptlets/install_checkbox_debs
+++ b/scriptlets/install_checkbox_debs
@@ -51,7 +51,7 @@ echo "  PPA that will be used: ppa:checkbox-dev/$RISK"
 echo "  See: https://code.launchpad.net/~checkbox-dev/+archive/ubuntu/$RISK"
 [ -n "$PROVIDERS" ] && echo "  Additional providers: $PROVIDERS"
 
-wait_for_packages_complete
+_run wait_for_packages_complete
 _run sudo add-apt-repository -y ppa:colin-king/ppa
 _run sudo add-apt-repository -y ppa:colin-king/stress-ng
 _run sudo add-apt-repository -y ppa:firmware-testing-team/ppa-fwts-stable
@@ -60,7 +60,7 @@ _run install_packages \
   checkbox-ng python3-checkbox-ng \
   checkbox-provider-base checkbox-provider-resource checkbox-provider-sru $PROVIDERS \
   fswebcam obexftp wmctrl iperf mesa-utils vim pastebinit fwts xorg-dev gir1.2-clutter-1.0
-wait_for_packages_complete
+_run wait_for_packages_complete
 
 export CHECKBOX_VERSION=$(retry --times 5 -- _run checkbox-cli --version)
 [ -z "$CHECKBOX_VERSION" ] && echo "Error: Unable to retrieve Checkbox version from device" && exit 1


### PR DESCRIPTION
## Description

For some reason `wait_for_packages_complete` in the `install_checkbox_debs` scriptlet was mistakenly executed on the agent rather than the host. Currently, `install_checkbox_debs` is not actually used in the SRU jobs so the issue went unnoticed.

## Tests

Tested successfully in the context of [this PR](https://github.com/canonical/hwcert-jenkins-jobs/pull/805), which installed the tools from this branch. 