### PR TITLE
Change: simpler command for 'wait service' busy loop

### DIFF
--- a/scriptlets/refresh_zapper_if_needed
+++ b/scriptlets/refresh_zapper_if_needed
@@ -42,6 +42,7 @@ fi
 set -e
 echo "Wait until the Zapper service is ready..."
 _run_retry zapper addon list &> /dev/null
+echo "...ready!"
 set +e
 
 # Update only the mainboard firmware. The add-on firmware is rarely updated,  

--- a/scriptlets/refresh_zapper_if_needed
+++ b/scriptlets/refresh_zapper_if_needed
@@ -39,6 +39,11 @@ if echo "$message" | grep -q 'no updates available'; then
     _run sudo snap restart zapper
 fi
 
+set -e
+echo "Wait until the Zapper service is ready..."
+_run_retry zapper --help 2> /dev/null
+set +e
+
 # Update only the mainboard firmware. The add-on firmware is rarely updated,  
 # and it's safer to do it manually for the time being.
-_run_retry zapper firmware update -y --allow-older --component-type MAINBOARD
+_run zapper firmware update -y --allow-older --component-type MAINBOARD

--- a/scriptlets/refresh_zapper_if_needed
+++ b/scriptlets/refresh_zapper_if_needed
@@ -41,7 +41,7 @@ fi
 
 set -e
 echo "Wait until the Zapper service is ready..."
-_run_retry zapper --help 2> /dev/null
+_run_retry zapper addon list 2> /dev/null
 set +e
 
 # Update only the mainboard firmware. The add-on firmware is rarely updated,  

--- a/scriptlets/refresh_zapper_if_needed
+++ b/scriptlets/refresh_zapper_if_needed
@@ -41,7 +41,7 @@ fi
 
 set -e
 echo "Wait until the Zapper service is ready..."
-_run_retry zapper addon list 2> /dev/null
+_run_retry zapper addon list &> /dev/null
 set +e
 
 # Update only the mainboard firmware. The add-on firmware is rarely updated,  


### PR DESCRIPTION
This scriplet is currently abusing a `_run_retry` to make sure the service is up and running and being restarted. While the end result is fine, there's no real need to *retry* that command in particular, and the errors printed while the service is starting are misleading and creates confusion to the user.

This PR makes use of a simpler command (a getter) as busy loop, redirecting both stdout and stderr to /dev/null.